### PR TITLE
Require JobOffersExport and nil verification

### DIFF
--- a/lib/dr_rockter.rb
+++ b/lib/dr_rockter.rb
@@ -1,4 +1,5 @@
 require "dr_rockter/version"
+require "dr_rockter/job_offers_export"
 
 module DrRockter
   class Error < StandardError; end

--- a/lib/dr_rockter.rb
+++ b/lib/dr_rockter.rb
@@ -1,5 +1,4 @@
 require "dr_rockter/version"
-require "dr_rockter/job_offers_export"
 
 module DrRockter
   class Error < StandardError; end

--- a/lib/dr_rockter/md.rb
+++ b/lib/dr_rockter/md.rb
@@ -7,7 +7,7 @@ module DrRockter
   module MD
     KNOWN_TYPES = {
       string:   ->(v) { v },
-      datetime: ->(v) { DateTime.parse v },
+      datetime: ->(v) { DateTime.parse v unless v.nil? },
       url:      ->(v) { URI(v) unless v.nil? }
     }
     DEFAULT_TYPE = KNOWN_TYPES[:string]


### PR DESCRIPTION
Two small things in this pull request :
- It adds a require to `dr_rockter/job_offers_export` in the main file
- The deserializer now returns nil for a date attribute that is `null` in a JSON 