### PR TITLE
Add hash type and test the MD class

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,8 +6,16 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
+    ansi (1.5.0)
+    builder (3.2.3)
     minitest (5.11.3)
+    minitest-reporters (1.3.6)
+      ansi
+      builder
+      minitest (>= 5.0)
+      ruby-progressbar
     rake (10.5.0)
+    ruby-progressbar (1.10.0)
 
 PLATFORMS
   ruby
@@ -16,6 +24,7 @@ DEPENDENCIES
   bundler (~> 2.0)
   dr_rockter!
   minitest (~> 5.0)
+  minitest-reporters (~> 1.3.0)
   rake (~> 10.0)
 
 BUNDLED WITH

--- a/dr_rockter.gemspec
+++ b/dr_rockter.gemspec
@@ -39,4 +39,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 2.0"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "minitest", "~> 5.0"
+  spec.add_development_dependency "minitest-reporters", "~> 1.3.0"
 end

--- a/lib/dr_rockter/md.rb
+++ b/lib/dr_rockter/md.rb
@@ -8,7 +8,8 @@ module DrRockter
     KNOWN_TYPES = {
       string:   ->(v) { v },
       datetime: ->(v) { DateTime.parse v unless v.nil? },
-      url:      ->(v) { URI(v) unless v.nil? }
+      url:      ->(v) { URI(v) unless v.nil? },
+      hash:     ->(v) { v }
     }
     DEFAULT_TYPE = KNOWN_TYPES[:string]
     

--- a/test/dr_rockter_test.rb
+++ b/test/dr_rockter_test.rb
@@ -4,8 +4,4 @@ class DrRockterTest < Minitest::Test
   def test_that_it_has_a_version_number
     refute_nil ::DrRockter::VERSION
   end
-
-  def test_it_does_something_useful
-    assert false
-  end
 end

--- a/test/md_test.rb
+++ b/test/md_test.rb
@@ -1,0 +1,131 @@
+require "test_helper"
+require "json"
+require "dr_rockter/md"
+
+module DrRockter
+  class CustomType
+    extend MD
+
+    json_attributes :custom_attr
+  end
+
+  class Test
+    extend MD
+
+    json_attributes a_hash: :hash, a_string: :string, a_url: :url, custom_type: CustomType, string_array: [:string], custom_type_array: [CustomType]
+  end
+
+  class TestUnknownDeserializer
+    extend MD
+
+    json_attributes unknown: :unknown_deserializer
+  end
+
+  class MDTest < Minitest::Test
+
+    def test_it_parses_a_string
+      json = <<~JSON
+      {
+        "a_string": "It is a string"
+      }
+      JSON
+      test = Test.json_create(JSON.parse(json))
+
+      assert_equal "It is a string", test.a_string
+    end
+
+    def test_it_parses_a_hash
+      json = <<~JSON
+      {
+        "a_hash": {
+          "first": "first",
+          "last": "last"
+        }
+      }
+      JSON
+      test = Test.json_create(JSON.parse(json))
+
+      assert_equal({ "first" => "first", "last" => "last" }, test.a_hash)
+    end
+
+    def test_it_parses_a_hash_with_null_value
+      json = <<~JSON
+      {
+        "a_hash": null
+      }
+      JSON
+      test = Test.json_create(JSON.parse(json))
+
+      assert_nil test.a_hash
+    end
+
+    def test_it_parses_a_url
+      url = "http://www.example.com"
+      json = <<~JSON
+      {
+        "a_url": "#{url}"
+      }
+      JSON
+      test = Test.json_create(JSON.parse(json))
+
+      assert_equal URI(url), test.a_url
+    end
+
+    def test_it_parses_a_custom_type
+      test = Test.json_create({ custom_type: { custom_attr: "custom attribute" } })
+
+      assert_instance_of CustomType, test.custom_type
+      assert_equal "custom attribute", test.custom_type.custom_attr
+    end
+
+    def test_it_parses_a_custom_type_with_null_value
+      json = <<~JSON
+      {
+        "custom_type": null
+      }
+      JSON
+      test = Test.json_create(JSON.parse(json))
+
+      assert_nil test.custom_type
+    end
+
+    def test_it_parses_an_array
+      json = <<~JSON
+      {
+        "string_array": ["a string", "another string"]
+      }
+      JSON
+      test = Test.json_create(JSON.parse(json))
+
+      assert_equal ["a string", "another string"], test.string_array
+    end
+
+    def test_it_parses_an_array_of_custom_types
+      json = <<~JSON
+      {
+        "custom_type_array": [
+          { "custom_attr": "a custom type" },
+          { "custom_attr": "another custom type" }
+        ]
+      }
+      JSON
+      test = Test.json_create(JSON.parse(json))
+
+      assert_instance_of Array, test.custom_type_array
+      assert_instance_of CustomType, test.custom_type_array.first
+      assert_instance_of CustomType, test.custom_type_array.last
+    end
+
+    def test_it_throws_an_exception_for_unknown_deserializer
+      json = <<~JSON
+      {
+        "unknown": "unknown"
+      }
+      JSON
+
+      assert_raises DeserializerError do
+        TestUnknownDeserializer.json_create(JSON.parse(json))
+      end
+    end
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -2,3 +2,6 @@ $LOAD_PATH.unshift File.expand_path("../../lib", __FILE__)
 require "dr_rockter"
 
 require "minitest/autorun"
+require "minitest/reporters"
+
+Minitest::Reporters.use! [Minitest::Reporters::DefaultReporter.new(:color => true)]


### PR DESCRIPTION
This PR adds a `hash` type in the `KNOWN_TYPES` array. It was already possible to parse a hash before but adding an explicit type allow to do something like this :
```ruby
MyClass
  extend DrRockter::MD

json_attributes my_hash: :hash
end
```

 I've also added a few test for the `MD` class.

Locally, I've also added a reporter for Minitest, juste to have some colors in the output. I can add it in this pull request if needed.