### PR TITLE
Add parsing of entity's address

### DIFF
--- a/lib/dr_rockter/entity.rb
+++ b/lib/dr_rockter/entity.rb
@@ -5,8 +5,8 @@ require "dr_rockter/hierarchy"
 module DrRockter
   class Entity
     extend MD
-    
-    json_attributes :public_name, :around, :internal_ref, :address, manager: NodeManagerInfo, hierarchy: Hierarchy
+
+    json_attributes :public_name, :around, :internal_ref, address: Address, manager: NodeManagerInfo, hierarchy: Hierarchy
 
     def hierarchy_node_name(column_name)
       hierarchy[column_name]&.public_name


### PR DESCRIPTION
`@job_offer.entity.address` retournait une hash.
On veut un joli objet (et ça tombe bien, on a déjà la même chose pour l'annonce) :)